### PR TITLE
Fix app crash during RN reload 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,17 @@ npm install react-native-sys-metrics
 ## Usage
 
 ```js
-import { reportCPUMetrics, SysMetrics } from 'react-native-sys-metrics';
+import { subscribeSystemMetrics, SysMetrics } from 'react-native-sys-metrics';
 
 // ...
-reportCPUMetrics((metrics: SysMetrics) => {
+subscribeSystemMetrics((metrics: SysMetrics) => {
   console.log(`got metrics: ${JSON.stringify(metrics)}`);
 });
 // ...
 ```
+
+## Testing
+You can test that your app handles the MetricKit payload by running your app in XCode on a real device and then selecting "Simulate MetricKit Payloads" from XCode's debug menu.
 
 ## Contributing
 

--- a/example/ios/File.swift
+++ b/example/ios/File.swift
@@ -1,6 +1,0 @@
-//
-//  File.swift
-//  SysMetricsExample
-//
-
-import Foundation

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -49,6 +49,11 @@ target 'SysMetricsExample' do
   end
 
   post_install do |installer|
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', '_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION']
+      end
+    end
     react_native_post_install(
       installer,
       # Set `mac_catalyst_enabled` to `true` in order to apply patches

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -329,7 +329,7 @@ PODS:
   - React-jsinspector (0.71.7)
   - React-logger (0.71.7):
     - glog
-  - react-native-sys-metrics (0.1.0):
+  - react-native-sys-metrics (0.1.1):
     - React-Core
   - React-perflogger (0.71.7)
   - React-RCTActionSheet (0.71.7):
@@ -606,7 +606,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: eaa5f71eb8f6861cf0e57f1a0f52aeb020d9e18e
   React-jsinspector: 9885f6f94d231b95a739ef7bb50536fb87ce7539
   React-logger: 3f8ebad1be1bf3299d1ab6d7f971802d7395c7ef
-  react-native-sys-metrics: fdad87880fdd875e30650cfbc92dcb9e5a5f4aa6
+  react-native-sys-metrics: bd2c3d2c114389af2762f832224890dc327bbb33
   React-perflogger: 2d505bbe298e3b7bacdd9e542b15535be07220f6
   React-RCTActionSheet: 0e96e4560bd733c9b37efbf68f5b1a47615892fb
   React-RCTAnimation: fd138e26f120371c87e406745a27535e2c8a04ef
@@ -624,6 +624,6 @@ SPEC CHECKSUMS:
   Yoga: d56980c8914db0b51692f55533409e844b66133c
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 2dfc80ae5d1fe3e229da16f93d206f3386eab57c
+PODFILE CHECKSUM: e28ed01ca752ed38d5109cd9c5185bce9bb90b7e
 
 COCOAPODS: 1.12.1

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 
 import { StyleSheet, View, Text } from 'react-native';
-import { reportCPUMetrics, SysMetrics } from 'react-native-sys-metrics';
+import { subscribeSystemMetrics, SysMetrics } from 'react-native-sys-metrics';
 
 export default function App() {
   const [result, setResult] = React.useState<SysMetrics | undefined>();
 
   React.useEffect(() => {
-    reportCPUMetrics(setResult);
+    subscribeSystemMetrics(setResult);
   }, []);
 
   return (

--- a/ios/SysMetrics.h
+++ b/ios/SysMetrics.h
@@ -5,8 +5,10 @@
 @interface SysMetrics : NSObject <NativeSysMetricsSpec>
 #else
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-@interface SysMetrics : NSObject <RCTBridgeModule>
+
+@interface SysMetrics : RCTEventEmitter <RCTBridgeModule>
 #endif
 
 @end

--- a/ios/SysMetrics.mm
+++ b/ios/SysMetrics.mm
@@ -4,7 +4,6 @@
 
 @interface SysMetrics() <MXMetricManagerSubscriber>
 
-@property (nonatomic, copy) RCTResponseSenderBlock callback;
 @property (nonatomic, strong) MXMetricManager *metricManager;
 @property (nonatomic, strong) NSMutableArray<MXCPUMetric *> *cpuMetrics;
 @property (nonatomic, strong) NSMutableArray<MXAppExitMetric *> *applicationExitMetrics;
@@ -32,17 +31,11 @@
 @end
 
 @implementation SysMetrics
+{
+  bool hasListeners;
+}
 
 RCT_EXPORT_MODULE();
-
-RCT_EXPORT_METHOD(reportCPUMetrics:(RCTResponseSenderBlock)callback) {
-    self->_callback = callback;
-    self->_cpuMetrics = [[NSMutableArray alloc] init];
-    self->_applicationExitMetrics = [[NSMutableArray alloc] init];
-    self->_applicationTimeMetrics = [[NSMutableArray alloc] init];
-    self->_memoryMetrics = [[NSMutableArray alloc] init];
-    [self subscribeToMetrics];
-}
 
 - (void)subscribeToMetrics {
     self->_metricManager = [MXMetricManager sharedManager];
@@ -52,6 +45,29 @@ RCT_EXPORT_METHOD(reportCPUMetrics:(RCTResponseSenderBlock)callback) {
 
 - (void)unsubscribeFromMetrics {
     [self->_metricManager removeSubscriber:self];
+}
+
+// Will be called when this module's first listener is added.
+-(void)startObserving {
+    hasListeners = YES;
+    self->_cpuMetrics = [[NSMutableArray alloc] init];
+    self->_applicationExitMetrics = [[NSMutableArray alloc] init];
+    self->_applicationTimeMetrics = [[NSMutableArray alloc] init];
+    self->_memoryMetrics = [[NSMutableArray alloc] init];
+    [self subscribeToMetrics];
+    // Set up any upstream listeners or background tasks as necessary
+}
+
+// Will be called when this module's last listener is removed, or on dealloc.
+-(void)stopObserving {
+    hasListeners = NO;
+    [self unsubscribeFromMetrics];
+    // Remove upstream listeners, stop unnecessary background tasks
+}
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[ @"SysMetrics" ];
 }
 
 - (void)didReceiveMetricPayloads:(NSArray<MXMetricPayload *> *)payloads {
@@ -79,30 +95,25 @@ RCT_EXPORT_METHOD(reportCPUMetrics:(RCTResponseSenderBlock)callback) {
         }
     }
     
-    if (self->_callback) {
+
+    if (hasListeners) { 
         NSMutableDictionary *metrics = [NSMutableDictionary dictionary];
         metrics[@"cpuMetrics"] = [self->_cpuMetrics mapObjectsUsingBlock:^(id obj, NSUInteger idx) {
-            return ((MXMetric *)obj).JSONRepresentation;
+            return ((MXMetric *)obj).dictionaryRepresentation;
         }];
         metrics[@"applicationExitMetrics"] = [self->_applicationExitMetrics mapObjectsUsingBlock:^(id obj, NSUInteger idx) {
-            return ((MXMetric *)obj).JSONRepresentation;
+            return ((MXMetric *)obj).dictionaryRepresentation;
         }];
         metrics[@"applicationTimeMetrics"] = [self->_applicationTimeMetrics mapObjectsUsingBlock:^(id obj, NSUInteger idx) {
-            return ((MXMetric *)obj).JSONRepresentation;
+            return ((MXMetric *)obj).dictionaryRepresentation;
         }];
         metrics[@"memoryMetrics"] = [self->_memoryMetrics mapObjectsUsingBlock:^(id obj, NSUInteger idx) {
-            return ((MXMetric *)obj).JSONRepresentation;
+            return ((MXMetric *)obj).dictionaryRepresentation;
         }];
-        self->_callback(@[metrics]);
+        [self sendEventWithName:@"SysMetrics" body:metrics];
     }
+    
 }
-
-- (void)dealloc {
-    [self unsubscribeFromMetrics];
-}
-
-
-
 
 // Don't compile this code when we build for the old architecture.
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sys-metrics",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "test",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/NativeSysMetrics.ts
+++ b/src/NativeSysMetrics.ts
@@ -1,9 +1,6 @@
-import type { TurboModule } from 'react-native';
-import { TurboModuleRegistry } from 'react-native';
-import type { SysMetrics } from 'react-native-sys-metrics';
-
+import { type TurboModule, TurboModuleRegistry } from 'react-native';
 export interface Spec extends TurboModule {
-  reportCPUMetrics(callback: (metrics: SysMetrics) => void): void;
+  addListener: (eventType: string) => void;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SysMetrics');


### PR DESCRIPTION
Fixes the issue where the RN reload in debug build would cause app to crash.  Also changed the native module to emit an event rather than fire a callback so that more than one MetricKit payload can be handled in an app session. 